### PR TITLE
Availabilities Decimal value fix

### DIFF
--- a/templates/helpers/availabilities.liquid
+++ b/templates/helpers/availabilities.liquid
@@ -59,7 +59,8 @@
                     <span>{{ date_range }}</span>
                     {%- unless time.unlimited? %}
                       {%- if time.available > 0 %}
-                        {{ "products.availability.available" | t: count: time.available }}
+                        {%- assign rounded_available = time.available | floor %}
+                        {{ "products.availability.available" | t: count: rounded_available }}
                       {%- else %}
                         {{ "products.availability.sold_out" | t }}
                       {%- endif %}


### PR DESCRIPTION
# Motivation
Starting from Version 18, a change was made to the decimal values displayed in the booking availability section, where a decimal value is now added to the available quantity. We should revert this change and restore the original format so that the field displays only the whole number value without a decimal.

# Solution
This Liquid code dynamically translates and displays product availability messages. It ensures that the availability count is rounded down and correctly formatted in different languages using the translation key `products.availability.available`

# Screenshot
![image](https://github.com/user-attachments/assets/cdd4bc20-172a-45cf-a4b7-c8a4d579fbc0)
