### PR TITLE
Update result_card.liquid - Replace api= {{ google api key }}

### DIFF
--- a/templates/snippets/locations/result_card.liquid
+++ b/templates/snippets/locations/result_card.liquid
@@ -74,7 +74,7 @@
         <a
           data-directions
           class="sc-hover-bg-primary-subtle sc-border-radius sc-one-half sc-p-small sc-font-tiny sc-font-bold sc-color-primary"
-          href="https://www.google.com/maps/dir/?api={{ google_maps_api_key }}"
+          href="https://www.google.com/maps/dir/?api=1"
           target="_blank">
           {{ "locations.search.results.menu.directions" | t }}
         </a>


### PR DESCRIPTION
## Fix for result_card snippet.
It currently includes `?api= {{ google api key }}`, this is not correct per [Google's documentation](https://developers.google.com/maps/documentation/urls/get-started).

the value should be `?api=1` to indicate the link came from off platform.  With the API key included, all direction links are broken and can potentially compromise a clients security through misuse of their API key.

I may be missing something so please reject if we are doing some liquid wizardry somewhere I couldn't see.