### PR TITLE
release/v21.0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Base Theme
 
-**Version: StoreConnect Release v21.0.4**
+**Version: StoreConnect Release v21.0.11**
 
 The StoreConnect Base theme is a clean and simple boilerplate ready for use. This starter theme is the default theme used in every StoreConnect installation.
 

--- a/controllers.csv
+++ b/controllers.csv
@@ -28,6 +28,7 @@ helpers/custom_form_answers,update
 helpers/delivery_options,index
 async/inbound_webhooks/bringg,create
 async/inbound_webhooks/easypost,create
+async/inbound_webhooks/easyship,create
 async/inbound_webhooks/ship24,create
 async/inbound_webhooks/ship_engine,create
 async/inbound_webhooks/shippit,create
@@ -66,6 +67,7 @@ auth/saml_sessions,saml_configuration
 auth/sessions,create
 auth/sessions,destroy
 auth/sessions,new
+balance_checks,create
 bundles,add_to_cart
 bundles,edit
 bundles,nested_configurator

--- a/templates/resources/package-lock.json
+++ b/templates/resources/package-lock.json
@@ -13,7 +13,7 @@
         "braintree-web": "^3.141.0",
         "hammerjs": "^2.0.8",
         "hoverintent": "^2.2.1",
-        "js-cookie": "^3.0.5",
+        "js-cookie": "^3.0.7",
         "litepicker": "^2.0.11",
         "normalize.css": "^8.0.1",
         "pikaday": "^1.8.2",
@@ -1743,11 +1743,12 @@
       "license": "MIT"
     },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
+      "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/lilconfig": {

--- a/templates/resources/package.json
+++ b/templates/resources/package.json
@@ -8,7 +8,7 @@
     "braintree-web": "^3.141.0",
     "hammerjs": "^2.0.8",
     "hoverintent": "^2.2.1",
-    "js-cookie": "^3.0.5",
+    "js-cookie": "^3.0.7",
     "litepicker": "^2.0.11",
     "normalize.css": "^8.0.1",
     "pikaday": "^1.8.2",

--- a/templates/resources/src/scripts/packs/bundle-v2.js
+++ b/templates/resources/src/scripts/packs/bundle-v2.js
@@ -179,9 +179,15 @@ function init(node) {
     },
 
     updateComponentQuantity(componentId, newQuantity) {
+      const card = node.querySelector(`[data-component-id="${componentId}"]`)
+
+      if (card?.hasAttribute('data-nested-bundle')) {
+        this.updateNestedBundleQuantity(componentId, newQuantity)
+        return
+      }
+
       let component = this.selectedComponents.get(componentId)
 
-      const card = node.querySelector(`[data-component-id="${componentId}"]`)
       const freeQuantity = parseInt(card?.getAttribute('data-free-quantity')) || 0
       const unitPrice = parseFloat(card?.getAttribute('data-unit-price')) || 0
 
@@ -233,6 +239,27 @@ function init(node) {
           this.updateGroupTotalQuantity(component.groupId)
           this.updateGroupDisplay(component.groupId)
         }
+      }
+
+      this.validateComponentGroups()
+    },
+
+    readNestedBundleQuantity(componentId) {
+      const input = node.querySelector(`[data-quantity-picker-component-id="${componentId}"]`)
+      const card = node.querySelector(`[data-component-id="${componentId}"]`)
+      const defaultQuantity = parseInt(card?.getAttribute('data-default-quantity')) || 1
+      const quantity = input ? parseInt(input.value) || defaultQuantity : defaultQuantity
+      return Math.max(1, quantity)
+    },
+
+    updateNestedBundleQuantity(componentId, newQuantity) {
+      const quantity = Math.max(1, newQuantity)
+      const component = this.selectedComponents.get(componentId)
+
+      if (component?.isNestedBundle) {
+        component.quantity = quantity
+        component.price = component.unitPrice * quantity
+        this.updateTotalPrice()
       }
 
       this.validateComponentGroups()
@@ -983,9 +1010,9 @@ function init(node) {
         }
       }
 
-      // Update pricing
+      // != null (not truthiness) so a $0 total still updates the label.
       const pricingElement = node.querySelector(`[data-nested-pricing="${componentId}"]`)
-      if (pricingElement && config.total) {
+      if (pricingElement && config.total != null) {
         pricingElement.textContent = `$${config.total.toFixed(2)}`
       }
 
@@ -1000,13 +1027,15 @@ function init(node) {
       // Store configuration
       this.nestedBundleConfigurations.set(componentId, config)
 
-      // Add nested bundle as a selected component for pricing
-      if (config.isConfigured && config.total) {
+      // Gate on isConfigured only — a $0 sub-bundle must still be submitted.
+      if (config.isConfigured) {
+        const quantity = this.readNestedBundleQuantity(componentId)
+        const total = config.total || 0
         this.selectedComponents.set(componentId, {
           product_id: componentId, // Use component ID as product ID for nested bundles
-          price: config.total,
-          quantity: 1,
-          unitPrice: config.total,
+          price: total * quantity,
+          quantity,
+          unitPrice: total,
           freeQuantity: 0,
           groupId: null,
           isNestedBundle: true,

--- a/templates/resources/src/scripts/packs/gateways/authorize-net.js
+++ b/templates/resources/src/scripts/packs/gateways/authorize-net.js
@@ -65,6 +65,8 @@ function initAuthorizeNet({ form }) {
       const payload = {
         payment_source: {
           tok_id: response.opaqueData['dataValue'],
+          billing_postal_code:
+            paymentForm.getFieldValue('billing_postal_code') || form.dataset.zipCode,
         },
       }
       paymentForm.submitData({ payload })

--- a/templates/resources/src/scripts/packs/gateways/nmi-ach.js
+++ b/templates/resources/src/scripts/packs/gateways/nmi-ach.js
@@ -1,7 +1,8 @@
 import { PaymentForm } from './payment-form'
 import { onDomChange } from '../../theme/utils/init'
 
-const NMI_ACH_FORM_SELECTOR = 'form[data-provider="NmiAch"]'
+const NMI_ACH_FORM_SELECTOR =
+  'form[data-provider="NmiAch"], form[data-provider="StoreConnectPayAch"]'
 
 onDomChange((node) => {
   const forms = node.querySelectorAll(NMI_ACH_FORM_SELECTOR)
@@ -211,7 +212,12 @@ function initNmiAch({ form }) {
       'data-tokenization-key': apiKey,
     },
     onload: () => {
-      configureCollectJs()
+      // Collect.js measures the iframe at configure time and gets stuck
+      // at height:0 if it runs against a display:none ancestor.
+      paymentForm.whenLaidOut(
+        paymentForm.formFieldElement('ach_account_number'),
+        configureCollectJs
+      )
     },
   })
 }

--- a/templates/resources/src/scripts/packs/gateways/nmi.js
+++ b/templates/resources/src/scripts/packs/gateways/nmi.js
@@ -1,7 +1,7 @@
 import { PaymentForm } from './payment-form'
 import { onDomChange } from '../../theme/utils/init'
 
-const NMI_FORM_SELECTOR = 'form[data-provider="Nmi"]'
+const NMI_FORM_SELECTOR = 'form[data-provider="Nmi"], form[data-provider="StoreConnectPay"]'
 
 onDomChange((node) => {
   const forms = node.querySelectorAll(NMI_FORM_SELECTOR)
@@ -15,9 +15,11 @@ onDomChange((node) => {
 
 function initNmi({ form }) {
   let isCollectJsReady = false
+  let isPaymentInProgress = false
 
   const paymentForm = new PaymentForm(form, {
     onSubmit: () => {
+      isPaymentInProgress = true
       return requestToken(paymentForm)
     },
   })
@@ -86,7 +88,11 @@ function initNmi({ form }) {
 
   function checkAllFieldsAndUpdateButton() {
     const allValid = Object.values(validationState).every((valid) => valid === true)
-    paymentForm.setPayButton(allValid)
+
+    // Don't re-enable button if payment/3DS flow is in progress
+    if (!isPaymentInProgress) {
+      paymentForm.setPayButton(allValid)
+    }
   }
 
   // Disable submit button by default until all fields are valid
@@ -113,10 +119,23 @@ function initNmi({ form }) {
         return
       }
 
+      // Collect.js builds an internal PaymentRequestAbstraction at configure
+      // time for any wallet (Apple Pay / Google Pay) enabled on the merchant
+      // account. It requires price/country/currency to do so, and logs
+      // "Could not create PaymentRequestAbstraction" to the console when they
+      // are missing — harmless for the card flow, but noisy in CI logs.
+      const totalPayable = paymentForm.totalPayable()
+      const price = totalPayable ? parseFloat(totalPayable).toFixed(2) : '0.00'
+      const country = form.dataset.billingCountry || 'US'
+      const currency = paymentForm.currency() || 'USD'
+
       // Use PaymentForm helpers to get element IDs for selectors
       // Pattern from stripe.js: `#${paymentForm.formFieldElement('card_number').id}`
       const config = {
         variant: 'inline',
+        price,
+        country,
+        currency,
         fields: {
           ccnumber: {
             selector: `#${cardNumberEl.id}`,
@@ -216,24 +235,264 @@ function initNmi({ form }) {
         card_bin: response.card?.bin, // First 6 digits
       }
 
-      const payload = {
-        payment_source: {
-          tok_id: response.token,
-          ...cardMetadata, // Spread card metadata into payment_source
-        },
-      }
+      // Check if 3DS is enabled
+      if (form.dataset.threeDSecure === 'true') {
+        prepareThreeDSecurePayload({ tokenResponse: response, cardMetadata, paymentForm })
+      } else {
+        const payload = {
+          payment_source: {
+            tok_id: response.token,
+            ...cardMetadata,
+          },
+        }
 
-      paymentForm.submitData({ payload })
+        paymentForm.submitData({ payload })
+      }
     } else {
+      isPaymentInProgress = false
+
       const errorMessage = response.error || paymentForm.i18n('errors.tokenization_failed')
       paymentForm.reportError('No token in NMI response', { response })
       paymentForm.showError(errorMessage)
     }
   }
 
+  function prepareThreeDSecurePayload({ tokenResponse, cardMetadata, paymentForm }) {
+    try {
+      const firstname = form.dataset.contactFirstname
+      const lastname = form.dataset.contactLastname
+      const email = form.dataset.contactEmail
+      const phone = form.dataset.contactPhone
+      const billingStreet = form.dataset.billingStreet
+      const billingCity = form.dataset.billingCity
+      const billingState = form.dataset.billingState
+      const billingCountry = form.dataset.billingCountry
+      const billingPostalCode = form.dataset.billingPostalCode
+
+      // NMI Gateway.js 3DS expects amount as a string in minor units (e.g. "1000" = $10.00).
+      const amount = Math.round(parseFloat(paymentForm.totalPayable() || '0') * 100).toString()
+
+      if (typeof Gateway === 'undefined') {
+        throw new Error('Gateway.js not loaded')
+      }
+
+      const gatewayKey = paymentForm.apiKey()
+      if (!gatewayKey) {
+        throw new Error('Gateway key not provided')
+      }
+
+      const gateway = Gateway.create(gatewayKey)
+      const threeDSecureService = gateway.get3DSecure()
+
+      // NMI docs: https://docs.nmi.com/docs/payer-authentication-3ds (Running 3DS with Collect.js)
+      // Field names are camelCase; amount is a string in minor units.
+      const threeDSecureOptions = {
+        paymentToken: tokenResponse.token,
+        amount: amount,
+        currency: paymentForm.currency() || 'USD',
+        firstName: firstname,
+        lastName: lastname,
+        email: email,
+        phone: phone,
+        address1: billingStreet,
+        city: billingCity,
+        state: billingState,
+        postalCode: billingPostalCode,
+        country: billingCountry,
+      }
+
+      // Mount the 3DS frame inside a dim-backdrop overlay so the
+      // ACS-rendered challenge UI (which we can't restyle) is visually
+      // isolated from the checkout page. The ACS iframe already renders its
+      // own card with title and chrome, so we deliberately do NOT wrap it in
+      // SC-Modal_inner — that would duplicate the header and add dead space.
+      // The overlay starts hidden; fingerprinting runs at 0x0 invisibly, and
+      // only when the challenge fires do we reveal the backdrop + iframe.
+      // NMI's start() takes a selector string, so the mount needs a stable id.
+      const providerId = form.dataset.providerId || ''
+      const mountId = `sc-nmi-threeds-${providerId}`
+      const modalId = `${mountId}-modal`
+      let threeDSecureModal = document.querySelector(`[data-modal="${modalId}"]`)
+      let threeDSecureContainer = threeDSecureModal?.querySelector(`#${mountId}`) || null
+      if (!threeDSecureModal) {
+        threeDSecureModal = document.createElement('div')
+        threeDSecureModal.className = 'SC-Modal SC-Modal--threeds'
+        threeDSecureModal.setAttribute('data-modal', modalId)
+        threeDSecureModal.setAttribute('data-ref', 'threeds-modal')
+        threeDSecureModal.innerHTML = `<div class="SC-Modal_overlay SC-Modal_overlay--dark-blur"></div>`
+        threeDSecureContainer = document.createElement('div')
+        threeDSecureContainer.id = mountId
+        threeDSecureContainer.className = 'SC-Modal--threeds_mount'
+        threeDSecureContainer.setAttribute('data-ref', 'threeds-container')
+        threeDSecureModal.appendChild(threeDSecureContainer)
+        document.body.appendChild(threeDSecureModal)
+      }
+
+      function cancelThreeDSecure(reason) {
+        failThreeDSecure(paymentForm.i18n('three_d_secure.cancelled'), {
+          reason,
+        })
+      }
+
+      function handleEscapeKey(event) {
+        if (event.key === 'Escape') {
+          cancelThreeDSecure('user_escape_key')
+        }
+      }
+
+      function showThreeDSecureModal() {
+        threeDSecureModal.classList.add('is-active')
+        document.body.style.overflow = 'hidden'
+
+        // Click on the dim backdrop (but not the iframe mount) cancels.
+        threeDSecureModal
+          .querySelector('.SC-Modal_overlay')
+          ?.addEventListener('click', () => cancelThreeDSecure('user_backdrop_click'))
+
+        document.addEventListener('keydown', handleEscapeKey)
+      }
+
+      function removeThreeDSecureModal() {
+        document.removeEventListener('keydown', handleEscapeKey)
+        // Tell NMI to tear down its internal ThreeDSecureUI state. Without
+        // this, removing the DOM node alone leaves NMI thinking the UI is
+        // still mounted, and the next createUI/start trips its "Another
+        // ThreeDSecureUI was started but has since been removed from the
+        // DOM" guard. Wrap in try/catch because NMI may have already
+        // unmounted itself on complete/failure/error.
+        try {
+          threeDSecureInterface?.unmount()
+        } catch (_) {
+          // Ignore — interface was already unmounted by NMI.
+        }
+        if (threeDSecureModal) {
+          threeDSecureModal.remove()
+          threeDSecureModal = null
+          threeDSecureContainer = null
+        }
+        document.body.style.overflow = ''
+      }
+
+      // Per NMI docs: createUI(options) returns an interface, then start(selector) mounts it.
+      // Event listeners must be attached to the interface, not the service.
+      const threeDSecureInterface = threeDSecureService.createUI(threeDSecureOptions)
+
+      // Watchdog: if Gateway.js never fires a terminal event (e.g. cmpiLookUp 400
+      // due to a misconfigured public key or an account not enabled for 3DS
+      // sandbox), the Pay Now button would stay in "Processing…" forever.
+      // Cancel on any terminal/challenge event below.
+      let threeDSecureWatchdog = setTimeout(() => {
+        threeDSecureWatchdog = null
+        failThreeDSecure(paymentForm.i18n('three_d_secure.confirmation_failed'), {
+          reason: 'watchdog_timeout',
+        })
+      }, 15000)
+
+      // Once 'complete' has fired we've already handed the payload to
+      // submitData; any later Gateway.js error is a no-op for the user. Without
+      // this flag, a late gateway-level error would tear down state and
+      // re-enable the Pay button mid-submission, inviting duplicate orders.
+      let threeDSecureSettled = false
+
+      function clearThreeDSecureWatchdog() {
+        if (threeDSecureWatchdog) {
+          clearTimeout(threeDSecureWatchdog)
+          threeDSecureWatchdog = null
+        }
+      }
+
+      function failThreeDSecure(message, context = {}) {
+        if (threeDSecureSettled) {
+          paymentForm.reportError('NMI 3DS late error after settle', context)
+          return
+        }
+        threeDSecureSettled = true
+        clearThreeDSecureWatchdog()
+        isPaymentInProgress = false
+
+        removeThreeDSecureModal()
+
+        paymentForm.showError(message)
+        paymentForm.reportError('NMI 3DS failed', context)
+      }
+
+      threeDSecureInterface.on('challenge', () => {
+        // Challenge UI is displayed — reveal the modal so the iframe is
+        // visible. Fingerprinting (which happens before this) stayed hidden.
+        clearThreeDSecureWatchdog()
+        showThreeDSecureModal()
+      })
+
+      threeDSecureInterface.on('complete', (threeDSecureData) => {
+        threeDSecureSettled = true
+        clearThreeDSecureWatchdog()
+        removeThreeDSecureModal()
+
+        // Build payload with 3DS authentication data.
+        // NMI returns camelCase property names in the complete event payload.
+        const payload = {
+          payment_source: {
+            tok_id: tokenResponse.token,
+            ...cardMetadata,
+            cavv: threeDSecureData.cavv,
+            eci: threeDSecureData.eci,
+            xid: threeDSecureData.xid,
+            directory_server_id: threeDSecureData.directoryServerId,
+            cardholder_auth: threeDSecureData.cardHolderAuth,
+            three_ds_version: threeDSecureData.threeDsVersion,
+          },
+        }
+
+        paymentForm.submitData({ payload })
+      })
+
+      threeDSecureInterface.on('failure', (error) => {
+        failThreeDSecure(error?.message || paymentForm.i18n('errors.verifying_payment'), {
+          reason: 'interface_failure',
+          error: error?.message,
+        })
+      })
+
+      // NMI docs list an interface-level "error" event for unknown/timeout
+      // scenarios (e.g. test card 4000000000002990). Without this handler the
+      // event was silently dropped.
+      threeDSecureInterface.on('error', (error) => {
+        failThreeDSecure(error?.message || paymentForm.i18n('three_d_secure.confirmation_failed'), {
+          reason: 'interface_error',
+          error: error?.message,
+        })
+      })
+
+      threeDSecureInterface.start(`#${mountId}`)
+
+      // Listen for Gateway.js errors (API key errors, configuration issues)
+      gateway.on('error', (error) => {
+        failThreeDSecure(
+          error?.message || paymentForm.i18n('three_d_secure.configuration_failed'),
+          {
+            reason: 'gateway_error',
+            error: error?.message,
+          }
+        )
+      })
+    } catch (error) {
+      isPaymentInProgress = false
+
+      const errorMessage =
+        error.message === 'Gateway.js not loaded'
+          ? paymentForm.i18n('three_d_secure.library_failed')
+          : error.message === 'Gateway key not provided'
+            ? paymentForm.i18n('three_d_secure.configuration_failed')
+            : paymentForm.i18n('three_d_secure.confirmation_failed')
+
+      paymentForm.showError(errorMessage)
+      paymentForm.reportError('NMI 3DS initialization failed', {
+        error: error.message,
+      })
+    }
+  }
+
   function requestToken(paymentForm) {
-    // Collect.js handles tokenization automatically on form submit
-    // when configured with variant: 'inline'
     try {
       if (typeof CollectJS === 'undefined' || !CollectJS.startPaymentRequest) {
         throw new Error('CollectJS not available')
@@ -250,6 +509,8 @@ function initNmi({ form }) {
 
       CollectJS.startPaymentRequest()
     } catch (error) {
+      isPaymentInProgress = false
+
       paymentForm.showError(paymentForm.i18n('errors.form_not_ready'))
       paymentForm.reportError('Failed to start NMI payment request', {
         error: error.message,
@@ -268,7 +529,21 @@ function initNmi({ form }) {
       'data-tokenization-key': apiKey,
     },
     onload: () => {
-      configureCollectJs()
+      // Collect.js measures the iframe at configure time and gets stuck
+      // at height:0 if it runs against a display:none ancestor.
+      paymentForm.whenLaidOut(paymentForm.formFieldElement('card_number'), configureCollectJs)
     },
   })
+
+  // Load Gateway.js for 3DS support (in parallel with Collect.js).
+  // URL comes from the server so sandbox and reseller hosts load from the
+  // matching origin instead of the production NMI host.
+  if (form.dataset.threeDSecure === 'true') {
+    const gatewayJsUrl = form.dataset.gatewayJsUrl
+    if (gatewayJsUrl) {
+      paymentForm.loadScript({ url: gatewayJsUrl })
+    } else {
+      paymentForm.reportError('NMI 3DS enabled but data-gateway-js-url missing')
+    }
+  }
 }

--- a/templates/resources/src/scripts/packs/gateways/payment-form.js
+++ b/templates/resources/src/scripts/packs/gateways/payment-form.js
@@ -215,6 +215,25 @@ export class PaymentForm {
     await loadExternalScript({ url, onload, id, attributes, container: scriptBlock })
   }
 
+  // Fires callback once probe has non-zero layout. Use to defer gateway
+  // SDK init past `display: none` ancestors that would measure as 0×0.
+  whenLaidOut(probe, callback) {
+    if (!probe || (probe.offsetWidth > 0 && probe.offsetHeight > 0)) {
+      callback()
+      return
+    }
+    // If the form is never revealed, the observer is left connected until
+    // the page unloads — there's no teardown hook on the form.
+    const observer = new ResizeObserver((entries) => {
+      const rect = entries[0].contentRect
+      if (rect.width > 0 && rect.height > 0) {
+        observer.disconnect()
+        callback()
+      }
+    })
+    observer.observe(probe)
+  }
+
   setPayButton(enabled) {
     // Support both boolean parameter and named argument { enabled: boolean }
     const isEnabled = typeof enabled === 'object' ? enabled.enabled : enabled

--- a/templates/resources/src/scripts/packs/gateways/vii.js
+++ b/templates/resources/src/scripts/packs/gateways/vii.js
@@ -1,0 +1,134 @@
+import { PaymentForm } from './payment-form'
+import storePathUrl from '../../theme/store-path-url'
+import { onDomChange } from '../../theme/utils/init'
+import { postJSON } from '../../theme/utils/fetch'
+
+onDomChange((node) => {
+  const forms = node.querySelectorAll('form[data-provider="Vii"]')
+  forms.forEach((form) => {
+    if (form.dataset.providerId) {
+      initVii({ form })
+    }
+  })
+})
+
+function initVii({ form }) {
+  const container = form.closest('[data-provider-container]') || form
+  const cardInput = container.querySelector('[data-vii-field="card-number"]')
+  const pinInput = container.querySelector('[data-vii-field="pin"]')
+  const balanceInput = container.querySelector('[data-vii-field="available-balance"]')
+  const checkButton = container.querySelector('[data-vii-check-balance]')
+  const checkButtonContainer = container.querySelector('[data-vii-check-balance-container]')
+  const balanceInfo = container.querySelector('[data-vii-balance-info]')
+
+  if (!cardInput || !pinInput || !checkButton || !balanceInfo) return
+
+  const paymentForm = new PaymentForm(form, {
+    onSubmit: () => {
+      paymentForm.submitData({
+        payload: {
+          payment_source: {
+            card_number: cardInput.value.trim(),
+            pin: pinInput.value.trim(),
+          },
+        },
+      })
+    },
+  })
+  const submitButton = paymentForm.submitElement()
+
+  function showCheckBalanceStep() {
+    checkButtonContainer?.classList.remove('sc-hide')
+    submitButton?.classList.add('sc-hide')
+    paymentForm.setPayButton(false)
+  }
+
+  function showPayStep() {
+    checkButtonContainer?.classList.add('sc-hide')
+    submitButton?.classList.remove('sc-hide')
+    paymentForm.setPayButton(true)
+  }
+
+  function clearBalance() {
+    if (balanceInput) balanceInput.value = ''
+    balanceInfo.classList.add('sc-hide')
+    balanceInfo.textContent = ''
+  }
+
+  showCheckBalanceStep()
+  ;[cardInput, pinInput].forEach((input) => {
+    input.addEventListener('input', () => {
+      clearBalance()
+      paymentForm.hideError()
+      showCheckBalanceStep()
+    })
+  })
+
+  checkButton.addEventListener('click', async (event) => {
+    event.preventDefault()
+
+    const cardNumber = cardInput.value.trim()
+    const pin = pinInput.value.trim()
+    if (!cardNumber || !pin) {
+      paymentForm.showError(
+        paymentForm.i18n('vii.missing_fields') || 'Enter your card number and PIN.'
+      )
+      return
+    }
+
+    paymentForm.hideError()
+    clearBalance()
+    checkButton.disabled = true
+
+    try {
+      const body = await postJSON(storePathUrl('/balance_checks'), {
+        provider_id: paymentForm.getProviderId(),
+        card_number: cardNumber,
+        pin: pin,
+      })
+      onBalanceResult(body)
+    } catch (error) {
+      paymentForm.showError(error.message)
+    } finally {
+      checkButton.disabled = false
+    }
+  })
+
+  function onBalanceResult(result) {
+    const balance = result ? Number(result.balance) : NaN
+
+    if (!result || !result.success || isNaN(balance)) {
+      const message =
+        (result && result.message) || paymentForm.i18n('vii.invalid_card') || 'Invalid card.'
+      paymentForm.showError(message)
+      showCheckBalanceStep()
+      return
+    }
+
+    if (balanceInput) balanceInput.value = formatMoney(balance)
+    const total = parseFloat(paymentForm.totalPayable())
+    if (!isNaN(total) && Math.round(balance * 100) >= Math.round(total * 100)) {
+      showPayStep()
+      return
+    }
+
+    balanceInfo.classList.remove('sc-hide', 'SC-Alert--info')
+    balanceInfo.classList.add('SC-Alert--error')
+    balanceInfo.textContent = formatInsufficientMessage(paymentForm, balance, total)
+    showCheckBalanceStep()
+  }
+}
+
+function formatInsufficientMessage(paymentForm, balance, total) {
+  const template =
+    paymentForm.i18n('vii.insufficient_balance') ||
+    'Card balance %{balance} is less than the order total %{total}.'
+  return template
+    .replace('%{balance}', formatMoney(balance))
+    .replace('%{total}', formatMoney(total))
+}
+
+function formatMoney(value) {
+  if (typeof value !== 'number' || isNaN(value)) return String(value)
+  return value.toFixed(2)
+}

--- a/templates/resources/src/styles/theme/components/modal.scss
+++ b/templates/resources/src/styles/theme/components/modal.scss
@@ -80,6 +80,29 @@
   }
 
   /**
+   * Modifier: 3DS Challenge
+   *
+   * The ACS iframe renders its own card (title, chrome, buttons), so we
+   * skip SC-Modal_inner entirely and just center the iframe over a dim
+   * backdrop. The iframe is sized by the ACS — we add horizontal scroll
+   * as a safety net for narrow phones where the frame may exceed viewport.
+   */
+
+  &--threeds {
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 5vh spacing('base') spacing('base');
+    overflow: auto;
+
+    &_mount {
+      position: relative;
+      z-index: var(--sc-depth-foreground);
+      max-width: 100%;
+    }
+  }
+
+  /**
    * Modifier: Nested Bundle Modal
    */
 

--- a/templates/snippets/checkout/payment_information/payment_providers/vii_form.liquid
+++ b/templates/snippets/checkout/payment_information/payment_providers/vii_form.liquid
@@ -1,0 +1,76 @@
+{%- assign button_label = 'checkout.gateways.vii.pay_now' | t %}
+
+<div data-provider-container="{{ payment_provider.code }}">
+  {%- form "payment", provider: payment_provider, class: "SC-Panel" %}
+    {{ payment_provider.description_content }}
+
+    <div class="SC-Fieldset">
+      <div class="SC-Field SC-Field-expand">
+        <label class="SC-Field_label" for="vii-card-number-{{ payment_provider.id }}">
+          {{ 'checkout.gateways.vii.card_number_label' | t }}
+        </label>
+        <input
+          type="text"
+          inputmode="numeric"
+          autocomplete="off"
+          id="vii-card-number-{{ payment_provider.id }}"
+          name="payment_source[card_number]"
+          class="SC-Field_input"
+          data-vii-field="card-number"
+          required
+        />
+      </div>
+
+      <div class="SC-Field SC-Field-small">
+        <label class="SC-Field_label" for="vii-pin-{{ payment_provider.id }}">
+          {{ 'checkout.gateways.vii.pin_label' | t }}
+        </label>
+        <input
+          type="password"
+          inputmode="numeric"
+          autocomplete="off"
+          id="vii-pin-{{ payment_provider.id }}"
+          name="payment_source[pin]"
+          class="SC-Field_input"
+          data-vii-field="pin"
+          required
+        />
+      </div>
+
+      <div class="SC-Field SC-Field-small">
+        <label class="SC-Field_label" for="vii-available-balance-{{ payment_provider.id }}">
+          {{ 'checkout.gateways.vii.available_balance_label' | t }}
+        </label>
+        <input
+          type="text"
+          id="vii-available-balance-{{ payment_provider.id }}"
+          class="SC-Field_input"
+          data-vii-field="available-balance"
+          readonly
+          tabindex="-1"
+          value=""
+        />
+      </div>
+
+      <div class="SC-Field" data-vii-check-balance-container>
+        <button
+          type="button"
+          class="SC-Button SC-Button-primary SC-Button-expanded-up-to-small"
+          data-vii-check-balance
+        >
+          {{ 'checkout.gateways.vii.check_balance_button' | t }}
+        </button>
+      </div>
+
+      <div class="SC-Field SC-Alert sc-hide" data-vii-balance-info></div>
+    </div>
+
+    {% render "checkout/payment_information/submit_button", button_label: button_label, disabled: true, hidden: true %}
+
+    {% render "checkout/payment_information/additional_info", form: form %}
+
+    {% render "checkout/payment_information/payment_error" %}
+  {%- endform %}
+
+  {%- require 'scripts/gateways/vii.js' %}
+</div>

--- a/templates/snippets/checkout/payment_information/select_and_payment.liquid
+++ b/templates/snippets/checkout/payment_information/select_and_payment.liquid
@@ -65,6 +65,10 @@
           {% render "checkout/payment_information/payment_providers/nmi_form", payment_provider: payment_provider %}
         {% when "NmiAch" %}
           {% render "checkout/payment_information/payment_providers/nmi_ach_form", payment_provider: payment_provider %}
+        {% when "StoreConnectPay" %}
+          {% render "checkout/payment_information/payment_providers/nmi_form", payment_provider: payment_provider %}
+        {% when "StoreConnectPayAch" %}
+          {% render "checkout/payment_information/payment_providers/nmi_ach_form", payment_provider: payment_provider %}
         {% when "Paypal" %}
           {% render "checkout/payment_information/payment_providers/paypal_form", payment_provider: payment_provider %}
         {% when "PayWay" %}
@@ -89,6 +93,8 @@
           {% render "checkout/payment_information/payment_providers/windcave_form", payment_provider: payment_provider %}
         {% when "ZippayAu" %}
           {% render "checkout/payment_information/payment_providers/zippay_au_form", payment_provider: payment_provider %}
+        {% when "Vii" %}
+          {% render "checkout/payment_information/payment_providers/vii_form", payment_provider: payment_provider %}
         {% else %}
           <p>Missing payment method - set it up now in <code>app/liquid/theme/snippets/checkout/payment_information/select_and_payment.liquid</code></p>
           <p>payment_provider.code = <code>{{ payment_provider.code }}</code></p>

--- a/templates/snippets/products/product/bundle/nested_bundle_card.liquid
+++ b/templates/snippets/products/product/bundle/nested_bundle_card.liquid
@@ -52,6 +52,10 @@
           {{ 'bundles.nested_bundle.configure_bundle' | t }}
         </button>
       </div>
+
+      {% render "products/product/bundle/component_quantity_picker",
+                 component: component,
+                 context: "card" %}
     </span>
   </div>
 {%- endif -%}

--- a/translations/en.default.csv
+++ b/translations/en.default.csv
@@ -507,12 +507,25 @@ checkout.gateways.form.bank_name,Bank name
 checkout.gateways.form.postal_code,Postal code
 checkout.gateways.afterpay.description_html,<p><strong>Interest free</strong> when you <strong>pay</strong> it in 4.</p>
 checkout.gateways.afterpay.terms_html,"<p style=""margin-top: 1rem;"">Afterpay late fees, eligibility criteria and terms & conditions apply. Visit <a class=""SC-Link"" target=""_blank"" href=""https://www.afterpay.com/en-AU/terms-of-service"">afterpay.com</a> for full terms.</p>"
+checkout.gateways.afterpay.line_items.payment_surcharge,Payment surcharge
+checkout.gateways.afterpay.line_items.rounding_adjustment,Rounding adjustment
+checkout.gateways.afterpay.line_items.discount,Discount
+checkout.gateways.afterpay.line_items.item,Item
+checkout.gateways.afterpay.line_items.balance_payment,Balance Payment
 checkout.gateways.free_form.no_payment_required,No payment required
 checkout.gateways.latitude.description_html,"<svg style=""max-width: 14rem; height: auto;"" xmlns=""http: //www.w3.org/2000/svg"" xml:space=""preserve"" viewBox=""0 0 303.3 50""><path d=""M235.5 25.9c0 3.9-1.6 7.1-6.1 7.1s-6.1-3.1-6.1-7.1v-12h-3.1v12.4c0 4.2 1.7 9.7 9.2 9.7s9.2-5.5 9.2-9.7V13.9h-3.1zm35.2-1.1c0-5-3.8-7.8-8.5-7.8h-5.6v15.6h5.6c4.7.1 8.5-2.7 8.5-7.8m3.2 0c0 7-5.1 10.9-11.4 10.9h-8.9V13.9h8.9c6.2 0 11.4 3.9 11.4 10.9m-150.6 1.6-4.1-9.4-4.1 9.4zm-2.5-12.5 9.9 21.9h-3.3l-2.7-6.2h-10.9l-2.7 6.3h-3.2l9.8-21.9h3.1zm18.4 3.1h7.4v18.8h3.1V17h7.4v-3.1h-18V17zm49.1 0h7.4v18.8h3.1V17h7.4v-3.1h-18V17zm-17.1 18.8h3.1V13.9h-3.1zM303.3 17v-3.1h-15.8v21.9h15.8v-3.1h-12.7v-6.3h10.9v-3.1h-10.9V17zM84 13.9h-3.1v21.9h15.8v-3.1H84zM8.7 0H0v50h50v-8.7H8.7zm23.2 8.7c5.8 0 5.8-8.7 0-8.7-5.9 0-5.9 8.7 0 8.7m13.7 18.8c-5.8 0-5.8 8.7 0 8.7 5.9 0 5.9-8.7 0-8.7M18.1 8.7C24 8.7 24 0 18.1 0s-5.8 8.7 0 8.7m27.5 5.1c-2.5-.1-4.5 1.9-4.5 4.4s2 4.4 4.5 4.4c5.7-.2 5.7-8.7 0-8.8M50 4.4c0 5.8-8.7 5.8-8.7 0 0-5.9 8.7-5.9 8.7 0m0 0"" style=""fill-rule:evenodd;clip-rule:evenodd;fill:#0046aa""/></svg><p><strong>Enjoy Now. Pay Later.</strong></p><p>Flexible Latitude interest Free plans to suit your needs.<p><p>We're here to help you get what you need. With plans from 6-24 months, Latitude has a range of Interest Free offers that work for you.</p><p>You will be redirected to Latitude checkout to complete your order.</p>"
 checkout.gateways.latitude.terms_html,"<p style=""margin-top: 1rem;"">Before continuing, you agree to our <a class=""SC-Link"" target=""_blank"" href=""https://www.latitudefinancial.com.au/terms-and-conditions/"">Terms & Conditions</a>.</p>"
 checkout.gateways.pay_by_account_form.account_on_credit_hold,"Account is on credit hold, please contact us for information."
 checkout.gateways.pay_by_account_form.enter_purchase_order_number,Enter Purchase Order Number
 checkout.gateways.pay_by_account_form.pay_now,Pay Now
+checkout.gateways.vii.card_number_label,Gift card number
+checkout.gateways.vii.pin_label,PIN
+checkout.gateways.vii.check_balance_button,Check balance
+checkout.gateways.vii.available_balance_label,Available balance
+checkout.gateways.vii.insufficient_balance,Card balance %{balance} is less than the order total %{total}.
+checkout.gateways.vii.invalid_card,We couldn't validate that card. Please check the number and PIN.
+checkout.gateways.vii.missing_fields,"Enter your gift card number and PIN, then check the balance."
+checkout.gateways.vii.pay_now,Pay with gift card
 checkout.gateways.pay_later_form.pay_now,Complete Purchase
 checkout.gateways.points_form.pay_now,Purchase
 checkout.gateways.store_credit_form.paying_with_account_credit,Paying with account credit
@@ -539,14 +552,17 @@ checkout.gateways.errors.tokenization_failed_ach,Failed to tokenize bank account
 checkout.gateways.errors.request_timeout,Payment request timed out. Please try again.
 checkout.gateways.errors.currency_not_supported,Payment method or currency not supported by merchant account.
 checkout.gateways.errors.token_expired,Payment token expired or already used. Please try again with a new card.
+checkout.gateways.errors.balance_check_not_available,Gift card payment is not available for this store.
 checkout.gateways.wallets.loading,Loading...
 checkout.gateways.wallets.no_shipping_required,No shipping required
 checkout.gateways.wallets.free,FREE
 checkout.gateways.apple_pay.setup_failed,Apple Pay setup failed. Please try another payment method.
 checkout.gateways.apple_pay.email_required,Email address is required but was not provided by Apple Pay
+checkout.gateways.three_d_secure.cancelled,3D Secure authentication was cancelled. Please try again to complete your payment.
 checkout.gateways.three_d_secure.library_failed,3D Secure library failed to load. Please try again.
 checkout.gateways.three_d_secure.unexpected_response,3D Secure returned an unexpected response; please try again.
 checkout.gateways.three_d_secure.confirmation_failed,Payment confirmation failed after 3D Secure authentication.
+checkout.gateways.three_d_secure.configuration_failed,3D Secure configuration error. Please contact support.
 checkout.payment.error,"Sorry, an error occurred while trying to process the payment. Please try again later."
 checkout.payment.timeout_error,We couldn't confirm your payment status. Please check your email or Orders page before trying again.
 checkout.payment.header,Payment
@@ -985,6 +1001,7 @@ sc.checkout.payment.shared.errors.phone_too_long,Phone number %{phone} is too lo
 sc.checkout.payment.shared.errors.provider_api_option_missing_key,Payment Provider missing API option %{key}
 sc.checkout.payment.shared.errors.amount_above_maximum,Order amount %{amount} exceeds the maximum of %{currency} %{maximum}.
 sc.checkout.payment.shared.errors.amount_below_minimum,Order amount %{amount} is below the minimum of %{currency} %{minimum}.
+sc.checkout.payment.shared.errors.amount_mismatch,Your cart was changed during payment. The amount charged does not match your order — please contact us to resolve.
 sc.checkout.payment.shared.errors.unsupported_currency,This payment provider only supports %{required_currency}. Your store currency is %{currency}.
 sc.checkout.payment.shared.errors.updating_subscription,We were unable to update your payment details!
 sc.checkout.payment.shared.errors.verifying_payment,We were unable to verify your payment!
@@ -1004,6 +1021,7 @@ sc.checkout.shipping.errors.some_items_not_shippable,Some of the items can not b
 sc.checkout.shipping.errors.tax_provider_offline,Tax provider offline. Please try again in a few minutes.
 sc.checkout.shipping.cart_item_name.custom,Shipping: %{label}
 sc.checkout.shipping.cart_item_name.provider,Shipping: %{provider}: %{label}
+sc.checkout.tax.default_name,Sales Tax
 sc.checkout.terms_and_conditions.errors.must_accept,Please accept the terms to continue
 sc.checkout.express.shipping.click_and_collect,%{location}. Collection point is %{point}.
 sc.errors.buy_button.add.fail,We were unable to add some or all of those items to your cart


### PR DESCRIPTION
## Summary

- Nested bundle pricing fix: Resolved a Liquid "internal" error when calculating cart pricing for bundles that contain nested bundles, and added a quantity picker for nested bundle components on the product card.
- Afterpay mid-payment cart change fix: Fixed Afterpay checkout failing silently when the cart was modified during payment; customers now see a clear error instead of a silent failure, and the order breakdown shows proper line-item labels (surcharge, rounding, discount, balance payment).
- StoreConnectPay gateway support: Added StoreConnectPay and StoreConnectPayAch as new checkout payment options, reusing the existing card and bank payment forms.
- 3D Secure checkout modal: Added a 3D Secure authentication modal for card payments, cleanly framing the bank's challenge screen over the checkout page.
- NMI bank payment fields fix: Fixed ACH bank account fields sometimes failing to render when the payment section loaded while hidden.
- Authorize.Net postal code fix: Fixed card payments not sending the billing postal code during tokenization.
- Vii gift card payment: Added a new gift card payment method at checkout, letting customers check their card balance before paying.